### PR TITLE
Upgrade googletest to 1.17.0

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -41,7 +41,7 @@ bazel_dep(
 bazel_dep(
     name = "googletest",
     # LINT.IfChange(gtest_version)
-    version = "1.16.0",
+    version = "1.17.0",
     # LINT.ThenChange(CMake/Googletest/Googletest.cmake:version)
     repo_name = "com_google_googletest",
 )


### PR DESCRIPTION
absl-cpp relies on googletest 1.17.0, and Bazel gives a warning when
transitive dependencies are more up to date than direct ones. It's
probably fine, but fewer warnings is nicer.

Also, this gives us a chance to test our infrastructure for accepting
external PRs.
