### PR TITLE
Fix MCContext constructor after LLVM API change

### DIFF
--- a/propeller/mini_disassembler.cc
+++ b/propeller/mini_disassembler.cc
@@ -90,7 +90,7 @@ MiniDisassembler::Create(const llvm::object::ObjectFile* object_file) {
   }
 
   disassembler->ctx_ = std::make_unique<llvm::MCContext>(
-      triple, *disassembler->asm_info_, disassembler->mri_.get(),
+      triple, disassembler->asm_info_.get(), disassembler->mri_.get(),
       disassembler->sti_.get());
   disassembler->disasm_ = absl::WrapUnique(
       target->createMCDisassembler(*disassembler->sti_, *disassembler->ctx_));

--- a/propeller/mini_disassembler.cc
+++ b/propeller/mini_disassembler.cc
@@ -90,8 +90,8 @@ MiniDisassembler::Create(const llvm::object::ObjectFile* object_file) {
   }
 
   disassembler->ctx_ = std::make_unique<llvm::MCContext>(
-      triple, *disassembler->asm_info_, *disassembler->mri_,
-      *disassembler->sti_);
+      triple, *disassembler->asm_info_, disassembler->mri_.get(),
+      disassembler->sti_.get());
   disassembler->disasm_ = absl::WrapUnique(
       target->createMCDisassembler(*disassembler->sti_, *disassembler->ctx_));
   if (disassembler->disasm_ == nullptr)

--- a/propeller/mini_disassembler.cc
+++ b/propeller/mini_disassembler.cc
@@ -90,7 +90,7 @@ MiniDisassembler::Create(const llvm::object::ObjectFile* object_file) {
   }
 
   disassembler->ctx_ = std::make_unique<llvm::MCContext>(
-      triple, disassembler->asm_info_.get(), disassembler->mri_.get(),
+      triple, *disassembler->asm_info_, disassembler->mri_.get(),
       disassembler->sti_.get());
   disassembler->disasm_ = absl::WrapUnique(
       target->createMCDisassembler(*disassembler->sti_, *disassembler->ctx_));


### PR DESCRIPTION
From what I understand, prior to this change `MCContext` was implemended as such in a couple of files:

```c++
disassembler->ctx_ = std::make_unique<llvm::MCContext>(
      triple, *disassembler->asm_info_, *disassembler->mri_,
      *disassembler->sti_);
```
This threw the following error: 
```/usr/include/c++/16.1.1/bits/unique_ptr.h:1086:30: error: no matching function for call to ‘llvm::MCContext::MCContext(llvm::Triple&, const llvm::MCAsmInfo&, const llvm::MCRegisterInfo&, const llvm::MCSubtargetInfo&)’```.

This *seems* to have broken; caused by a change to the LLVM internal API.

Note, this might break compatibility with older LLVM/Clang versions; testing in progress.

Also, this is my first PR to a large repo, so feedback is welcome (im only 14, sorry)
